### PR TITLE
Output query latencies and statistics

### DIFF
--- a/percona_playback/mysql_client/mysql_client.cc
+++ b/percona_playback/mysql_client/mysql_client.cc
@@ -170,6 +170,10 @@ bool MySQLDBThread::test_connect(MySQLOptions* opt) {
   thread->queries->push(boost::make_shared<FinishEntry>());
   thread->start_thread();
   thread->join();
+
+  /* test connection */
+  thread->connect();
+  thread->disconnect();
   return thread->num_connect_errors == 0;
 }
 

--- a/percona_playback/simple_report/simple_report.cc
+++ b/percona_playback/simple_report/simple_report.cc
@@ -292,12 +292,14 @@ public:
     }
 
     // query report has the statistics like duration, thread id, etc.
-    QueryReport query_report;
-    query_report.set_thread_id(thread_id);
-    query_report.set_duration_us(actual.getDuration().total_microseconds());
-    query_report_results.push(query_report);
+    if (actual.getDuration().total_microseconds() > 0) {
+      QueryReport query_report;
+      query_report.set_thread_id(thread_id);
+      query_report.set_duration_us(actual.getDuration().total_microseconds());
+      query_report_results.push(query_report);
+    }
     if (nr_queries_executed % report_interval == 0)
-        std::cout << nr_queries_executed << " queries are executed" << std::endl;
+      std::cout << nr_queries_executed << " queries are executed" << std::endl;
   }
 
   virtual void print_report()

--- a/percona_playback/simple_report/simple_report.cc
+++ b/percona_playback/simple_report/simple_report.cc
@@ -139,8 +139,11 @@ public:
 
     if (!ignore_row_result_diffs && actual.getRowsSent() != expected.getRowsSent())
     {
-      nr_queries_rows_differ++;
-      fprintf(stderr, _("Connection %"PRIu64" Rows Sent: %"PRIu64 " != expected %"PRIu64 " for query: %s\n"), thread_id, actual.getRowsSent(), expected.getRowsSent(), query.c_str());
+      /* Skip this if the input log is general log, because it does not have rows information (value is always 0).*/
+      if (expected.getRowsSent() > 0) {
+        nr_queries_rows_differ++;
+        fprintf(stderr, _("Connection %"PRIu64" Rows Sent: %"PRIu64 " != expected %"PRIu64 " for query: %s\n"), thread_id, actual.getRowsSent(), expected.getRowsSent(), query.c_str());
+      }
     }
 
     nr_queries_executed++;


### PR DESCRIPTION
Output all query latencies to the `results.txt` file, and summary statistics (like p99, p95, p90 latency) to the `summary.txt` file